### PR TITLE
Generate cryptographically secure session IDs

### DIFF
--- a/wai-session.cabal
+++ b/wai-session.cabal
@@ -37,6 +37,8 @@ library
                 base == 4.*,
                 containers,
                 bytestring,
+                bytestring-builder,
+                entropy,
                 transformers,
                 time,
                 StateVar,


### PR DESCRIPTION
Looks like the generated session IDs are predictable. I've changed the generator function to use cryptographically secure random byte sequences.

See also https://www.owasp.org/index.php/Session_Prediction