### PR TITLE
Don't modify response on ResponseRaw instead of throwing an error

### DIFF
--- a/Network/Wai/Session.hs
+++ b/Network/Wai/Session.hs
@@ -90,7 +90,7 @@ mapHeader f (ResponseFile s h b1 b2) = ResponseFile s (f h) b1 b2
 mapHeader f (ResponseBuilder s h b) = ResponseBuilder s (f h) b
 #if MIN_VERSION_wai(3,0,0)
 mapHeader f (ResponseStream s h b) = ResponseStream s (f h) b
-mapHeader _ (ResponseRaw _ _) = error "Cannot mapHeader of Wai.Interal.ResponseRaw when trying to add session cookie header"
+mapHeader _ r@(ResponseRaw _ _) = r
 #else
 mapHeader f (ResponseSource s h b) = ResponseSource s (f h) b
 #endif


### PR DESCRIPTION
Headers can't be modified on `ResponseRaw` responses. These happen in situations like a WebSocket connection.

I think it's a much better idea to return the response unmodified instead of erroring here. Otherwise the middleware is unusable in an application that possibly uses WebSockets.